### PR TITLE
Locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 grunt-locale-html
 =================
 
-Version 0.1.1
+Version 0.2.1
 
 Grunt plugin to generage translated HTML files based on an HTML template that uses underscore.js templating.  This plugin requires you to provide a .tmx file.  A reference i18n file will be created so the user can refer to variable names to use in the template.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-locale-html",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "Translates an HTML file with provided data.",
   "main": "index.js",
   "scripts": {

--- a/tasks/locale-html.js
+++ b/tasks/locale-html.js
@@ -35,6 +35,7 @@ module.exports = function(grunt) {
                 locales.forEach(function(locale) {
                     i18nReference[locale] = {};
 
+                    i18nReference[locale].localeId = locale;
                     i18nReference[locale].localeCode = locale === 'en' ? '' : locale;
 
                     // TODO - These will not work when multiple translations


### PR DESCRIPTION
Added localeId. Essentially the same as localeCode, but localeCode is blank for EN. I needed access to the current locale and cannot use the key of the i18n obj

If merged, please tag v0.2.1